### PR TITLE
Fixed mysql volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 services:
  mysqldb:
    image: mysql
-   container_name: jackhmmaer-db
+   container_name: jackhammer-db
    environment:
      MYSQL_ROOT_PASSWORD: root
      MYSQL_USER: root
@@ -15,7 +15,7 @@ services:
    ports:
      - "3306:3306"
    volumes: 
-      - mysql-data:/usr/local/bin/mysql
+      - mysql-data:/var/lib/mysql
    restart: always
    healthcheck:
      test: "nc -z localhost 3306"


### PR DESCRIPTION
Fix for  [ISSUE-32](https://github.com/olacabs/jackhammer/issues/32) 
To use the data volume in a different container 
`docker run  -it -p 3305:3306 -v jackhammer_mysql-data:/var/lib/mysql  mysql `